### PR TITLE
Reject empty strings in Index.name/1

### DIFF
--- a/lib/elastic/index.ex
+++ b/lib/elastic/index.ex
@@ -12,7 +12,7 @@ defmodule Elastic.Index do
   """
   def name(index) do
     [index_prefix(), mix_env(), index]
-    |> Enum.reject(&(&1 == nil))
+    |> Enum.reject(&(&1 == nil || &1 == ""))
     |> Enum.join("_")
   end
 
@@ -118,7 +118,7 @@ defmodule Elastic.Index do
 
   defp mix_env do
     if Application.get_env(:elastic, :use_mix_env),
-      do: Mix.env,
+      do: Mix.env(),
       else: nil
   end
 end

--- a/test/elastic/index_test.exs
+++ b/test/elastic/index_test.exs
@@ -1,7 +1,14 @@
 defmodule Elastic.IndexTest do
   use ExUnit.Case
+  import ElasticTestUtil
 
   test "build_index uses the index_prefix" do
     assert Elastic.Index.name("answer") == "elastic_test_answer"
+  end
+
+  test "Index.name/1 rejects empty strings" do
+    with_application_env(:elastic, :index_prefix, "", fn ->
+      assert Elastic.Index.name("answer") == "test_answer"
+    end)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,3 +15,16 @@ defmodule Question do
 
   defstruct [:id, :text, :comments]
 end
+
+defmodule ElasticTestUtil do
+  def with_application_env(app, key, new, context) do
+    old = Application.get_env(app, key)
+    Application.put_env(app, key, new)
+
+    try do
+      context.()
+    after
+      Application.put_env(app, key, old)
+    end
+  end
+end


### PR DESCRIPTION
After accidentally setting `index_prefix` to `""`, `Index.name/1` returns `"_my-index"` when making search requests or scrolling (I've spent an hour trying to figure out why Elasticsearch is returning empty hits). To prevent this from happening again, I think rejecting empty strings would be handy.

Thanks for the awesome work!