### PR TITLE
Set AWS Authorization using headers, not params

### DIFF
--- a/lib/elastic/aws.ex
+++ b/lib/elastic/aws.ex
@@ -4,8 +4,8 @@ defmodule Elastic.AWS do
     settings()[:enabled]
   end
 
-  def sign_url(method, url, headers, body) do
-    AWSAuth.sign_url(
+  def authorization_headers(method, url, headers, body) do
+    AWSAuth.sign_authorization_header(
       settings().access_key_id,
       settings().secret_access_key,
       to_string(method),
@@ -13,7 +13,6 @@ defmodule Elastic.AWS do
       settings().region,
       "es",
       process_headers(method, headers),
-      DateTime.utc_now() |> DateTime.to_naive(),
       body
     )
   end


### PR DESCRIPTION
Fixes #23.

Have so far just checked on AWS ES 6.4. Will need to check on other AWS versions.