### PR TITLE
Fix aws auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ defp deps do
 
 ```elixir
 def application do
-  [applications: [:elastic]]
+  [extra_applications: [:elastic]]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Elastic.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpotion]]
+    [applications: [:logger, :httpotion, :aws_auth, :jason]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
The package is missing some required applications from the list of applications in `mix.exs`, this is forcing application code to include `:aws_auth` and `:jason` as applications in there mix.exs to use this library even though they are actually dependencies of `elastic`.