### PR TITLE
fixed query timeout and json decoding error

### DIFF
--- a/lib/elastic/http.ex
+++ b/lib/elastic/http.ex
@@ -100,7 +100,7 @@ defmodule Elastic.HTTP do
       options
       |> Keyword.put_new(:headers, Keyword.new())
       |> Keyword.put(:body, body)
-      |> Keyword.put(:connect_timeout, timeout)
+      |> Keyword.put(:timeout, timeout)
       |> add_content_type_header
       |> add_aws_header(method, url, body)
       |> add_basic_auth


### PR DESCRIPTION
- The previous connect timeout did not work, since the only option HTTPotion provided for a timeout was "timeout" and not "connect_timeout"
- When there was a JSON decoding error the output was difficult to analyse, now the error is much clearer
