### PR TITLE
fixed query timeout and json decoding error

### DIFF
--- a/lib/elastic/http.ex
+++ b/lib/elastic/http.ex
@@ -100,7 +100,7 @@ defmodule Elastic.HTTP do
       options
       |> Keyword.put_new(:headers, Keyword.new())
       |> Keyword.put(:body, body)
-      |> Keyword.put(:connect_timeout, timeout)
+      |> Keyword.put(:timeout, timeout)
       |> add_content_type_header
       |> add_aws_header(method, url, body)
       |> add_basic_auth

--- a/lib/elastic/response_handler.ex
+++ b/lib/elastic/response_handler.ex
@@ -2,7 +2,14 @@ defmodule Elastic.ResponseHandler do
   @moduledoc false
 
   def process(%{body: body, status_code: status_code}) when status_code in 400..599 do
-    {:error, status_code, decode_body(body)}
+    case decode_body(body) do 
+      {:ok, decoded_body} -> 
+        {:error, status_code, decoded_body}
+
+      {:error, error} ->
+        json_error(error)
+  end  
+    
   end
 
   def process(%{body: body, status_code: status_code}) do
@@ -10,9 +17,8 @@ defmodule Elastic.ResponseHandler do
       {:ok, decoded_body} ->
         {:ok, status_code, decoded_body}
 
-      {:error, error} ->
-        {:error, 0,
-          %{"error" => "Could not decode response into JSON, error: #{inspect(Jason.DecodeError.message(error))}"}}
+       {:error, error} ->
+        json_error(error)
     end
   end
 
@@ -36,9 +42,12 @@ defmodule Elastic.ResponseHandler do
      %{"error" => "Could not connect to Elasticsearch: request timed out (req_timedout)"}}
   end
 
-  defp decode_body("") do
-    ""
-  end
+  defp json_error(error) do 
+    {:error, 0,
+     %{"error" => "Could not decode response into JSON, error: #{inspect(Jason.DecodeError.message(error))}"}}  
+  end  
+
+  defp decode_body(""), do: ""
 
   defp decode_body(body) do
     with {:ok, decoded_body} <- Jason.decode(body), do: {:ok, decoded_body}


### PR DESCRIPTION
- The previous connect timeout did not work, since the only option HTTPotion provided for a timeout was "timeout" and not "connect_timeout"

- When there was a JSON decoding error the output was difficult to analyse, now the error is much clearer