### PR TITLE
Use PUT keyword to create index with parameters

### DIFF
--- a/lib/elastic/index.ex
+++ b/lib/elastic/index.ex
@@ -51,7 +51,7 @@ defmodule Elastic.Index do
   """
 
   def create(index, parameters) do
-    HTTP.post(name(index), body: parameters)
+    HTTP.put(name(index), body: parameters)
   end
 
   @doc """

--- a/lib/elastic/index.ex
+++ b/lib/elastic/index.ex
@@ -69,7 +69,7 @@ defmodule Elastic.Index do
 
   """
   def delete(index) do
-    index |> name |> HTTP.delete
+    index |> name |> HTTP.delete()
   end
 
   @doc """
@@ -84,7 +84,7 @@ defmodule Elastic.Index do
   The index name will be automatically prefixed as per this package's configuration.
   """
   def exists?(index) do
-    {_, status, _} = index |> name |> HTTP.head
+    {_, status, _} = index |> name |> HTTP.head()
     status == 200
   end
 

--- a/test/elastic/integration/index_test.exs
+++ b/test/elastic/integration/index_test.exs
@@ -20,6 +20,20 @@ defmodule Elastic.Integration.IndexTest do
     assert %{"status" => "open"} = cat_result
   end
 
+  @tag integration: true
+  test "create/1" do
+    result_create = Index.create("index_test_create")
+
+    assert {:ok, 200, _} = result_create
+  end
+
+  @tag integration: true
+  test "create/2" do
+    result_create = Index.create("index_test_create", %{ mappings: %{}})
+
+    assert {:ok, 200, _} = result_create
+  end
+
   defp get_index_response({:ok, 200, indices}, name) do
     indices
     |> Enum.find(&(&1["index"] == name))

--- a/test/elastic/integration/index_test.exs
+++ b/test/elastic/integration/index_test.exs
@@ -29,7 +29,7 @@ defmodule Elastic.Integration.IndexTest do
 
   @tag integration: true
   test "create/2" do
-    result_create = Index.create("index_test_create", %{ mappings: %{}})
+    result_create = Index.create("index_test_create", %{mappings: %{}})
 
     assert {:ok, 200, _} = result_create
   end

--- a/test/support/integration_test_case.ex
+++ b/test/support/integration_test_case.ex
@@ -9,6 +9,8 @@ defmodule Elastic.IntegrationTestCase do
     Elastic.Index.create("answer")
     Elastic.Index.create("existence")
 
+    Elastic.Index.delete("index_test_create")
+
     {:ok, tags}
   end
 end


### PR DESCRIPTION
When creating an index with parameters (custom analyzer + mapping) I received the error 405 method not allowed as it was a POST and not a PUT. 
